### PR TITLE
Tested against Python 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,15 @@ env:
   - TOXENV=py34-master
 
 matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35-1.9
+    - python: 3.5
+      env: TOXENV=py35-master
   allow_failures:
     - env: TOXENV=py27-master
     - env: TOXENV=py34-master
+    - env: TOXENV=py35-master
 
 install:
   - pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     py27-{1.8,1.9,master},
     py32-{1.8},
     py33-{1.8},
-    py34-{1.8,1.9,master}
+    py34-{1.8,1.9,master},
+    py35-{1.9,master}
 
 [testenv]
 basepython =
@@ -14,13 +15,14 @@ basepython =
     py32: python3.2
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 usedevelop = true
 commands =
     {envpython} -R -Wonce {envbindir}/coverage run {envbindir}/django-admin.py test -v2 --settings=tests.settings {posargs}
     coverage report
 deps =
     py32: coverage<4.0
-    {py27,py33,py34}: coverage
+    {py27,py33,py34,py35}: coverage
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     master: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Since it's not part of the TravisCI base image yet we have to explicitly define
it in the build matrix.