### PR TITLE
Fix caching bug after type_casting a child model

### DIFF
--- a/polymodels/models.py
+++ b/polymodels/models.py
@@ -60,6 +60,10 @@ class SubclassAccessors(object):
         try:
             return self.cache[cache_key]
         except KeyError:
+            for o in owner.mro():
+                if issubclass(o, PolymorphicModel) and o is o._meta.get_field(o.CONTENT_TYPE_FIELD).model:
+                    owner = o
+                    break
             for model in opts.apps.get_models():
                 if issubclass(model, owner):
                     self.cache_accessors(model)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -105,6 +105,13 @@ class BasePolymorphicModelTest(TestCase):
                 'Two level proxy type casting should work'
             )
 
+    def test_type_cast_on_child_class(self):
+        mammal = Mammal.objects.create()
+        snake = Snake.objects.create(length=1)
+
+        self.assertEqual(mammal.type_cast(), mammal)
+        self.assertEqual(snake.animal_ptr.type_cast(), snake)
+
 
 class SubclassAccessorsTests(SimpleTestCase):
     def test_dynamic_model_creation_cache_busting(self):


### PR DESCRIPTION
This was broken in e62412b701331467cb135a3f9fc7b0b706e77843.

The fix I did is pretty hacky -- hopefully you will be able to use the test to write a cleaner fix.