### PR TITLE
Fixed #22 -- Skipped queryset type casting when a non-model iterable is used.

### DIFF
--- a/polymodels/compat.py
+++ b/polymodels/compat.py
@@ -16,6 +16,18 @@ else:
     def get_remote_model(remote_field):
         return remote_field.to
 
+# TODO: Remove the following when support for Django 1.8 is dropped
+try:
+    from django.db.models.query import ModelIterable
+except ImportError:
+    def is_model_iterable(queryset):
+        return True
+else:
+    def is_model_iterable(queryset):
+        return issubclass(queryset._iterable_class, ModelIterable)
+
+
+# TODO: Remove the following when support for Django 1.9 is dropped
 try:
     from django.db.models.fields.related import lazy_related_operation
 except ImportError:

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -69,6 +69,12 @@ class PolymorphicQuerySetTest(TestCase):
                                      ['<BigSnake: big snake>',
                                       '<HugeSnake: huge snake>'])
 
+    def test_select_subclasses_values(self):
+        Animal.objects.create(name='animal')
+        self.assertQuerysetEqual(
+            Animal.objects.select_subclasses().values_list('name', flat=True), ['animal'], lambda x: x
+        )
+
     def test_exclude_subclasses(self):
         Animal.objects.create(name='animal')
         Mammal.objects.create(name='first mammal')


### PR DESCRIPTION
Thanks to Gavin Wahl for the report.