### PR TITLE
Fixed select_subclasses().prefetch_related() usage on mixed types.

### DIFF
--- a/polymodels/managers.py
+++ b/polymodels/managers.py
@@ -1,14 +1,27 @@
 from __future__ import unicode_literals
 
+from functools import partial
+from operator import methodcaller
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import ModelIterable
+from django.utils.six.moves import map
+
+
+type_cast_iterator = partial(map, methodcaller('type_cast'))
 
 
 class PolymorphicModelIterable(ModelIterable):
+    def __init__(self, queryset, type_cast=True, **kwargs):
+        self.type_cast = type_cast
+        super(PolymorphicModelIterable, self).__init__(queryset, **kwargs)
+
     def __iter__(self):
-        for instance in super(PolymorphicModelIterable, self).__iter__():
-            yield instance.type_cast()
+        iterator = super(PolymorphicModelIterable, self).__iter__()
+        if self.type_cast:
+            iterator = type_cast_iterator(iterator)
+        return iterator
 
 
 class PolymorphicQuerySet(models.query.QuerySet):
@@ -48,6 +61,23 @@ class PolymorphicQuerySet(models.query.QuerySet):
 
     def exclude_subclasses(self):
         return self.filter(**self.model.content_type_lookup())
+
+    def _fetch_all(self):
+        # Override _fetch_all in order to disable PolymorphicModelIterable's
+        # type casting when prefetch_related is used because the latter might
+        # crash or disfunction when dealing with a mixed set of objects.
+        prefetch_related_objects = self._prefetch_related_lookups and not self._prefetch_done
+        type_cast = False
+        if self._result_cache is None:
+            iterable_class = self._iterable_class
+            if issubclass(iterable_class, PolymorphicModelIterable):
+                type_cast = bool(prefetch_related_objects)
+                iterable_class = partial(iterable_class, type_cast=not type_cast)
+            self._result_cache = list(iterable_class(self))
+        if prefetch_related_objects:
+            self._prefetch_related_objects()
+            if type_cast:
+                self._result_cache = list(type_cast_iterator(self._result_cache))
 
 
 class PolymorphicManager(models.Manager.from_queryset(PolymorphicQuerySet)):

--- a/tests/models.py
+++ b/tests/models.py
@@ -37,6 +37,8 @@ class Mammal(Animal):
 
 
 class Monkey(Mammal):
+    friends = models.ManyToManyField('self')
+
     class Meta:
         app_label = 'polymodels'
 


### PR DESCRIPTION
The prefetching logic expects the result set to be of the same type and might crash or disfunction if it's not the case.

Fixes #42.