### PR TITLE
Django 3.0/3.1 compatibility. Close #50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,13 @@ matrix:
     dist: xenial
     sudo: true
   - python: 3.6
+    env: TOXENV=py36-3.0
+    dist: xenial
+    sudo: true
+  - python: 3.6
     env: TOXENV=py36-master
+    dist: xenial
+    sudo: true
   - python: 3.7
     env: TOXENV=py37-2.0
     dist: xenial
@@ -49,7 +55,19 @@ matrix:
     dist: xenial
     sudo: true
   - python: 3.7
+    env: TOXENV=py37-3.0
+    dist: xenial
+    sudo: true
+  - python: 3.7
     env: TOXENV=py37-master
+    dist: xenial
+    sudo: true
+  - python: 3.8
+    env: TOXENV=py38-3.0
+    dist: xenial
+    sudo: true
+  - python: 3.8
+    env: TOXENV=py38-master
     dist: xenial
     sudo: true
   allow_failures:

--- a/polymodels/__init__.py
+++ b/polymodels/__init__.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 5, 1, 'final', 0)
+VERSION = (1, 6, 0, 'final', 0)
 
 __version__ = get_version(VERSION)

--- a/polymodels/fields.py
+++ b/polymodels/fields.py
@@ -10,8 +10,9 @@ from django.db.models.fields.related import (
 )
 from django.utils.deconstruct import deconstructible
 from django.utils.functional import LazyObject, empty
-from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _
+
+from six import string_types
 
 from .models import BasePolymorphicModel
 from .utils import get_content_type

--- a/polymodels/forms.py
+++ b/polymodels/forms.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
 from django.forms import models
-from django.utils.six import with_metaclass
+
+from six import with_metaclass
 
 
 class PolymorphicModelFormMetaclass(models.ModelFormMetaclass):

--- a/polymodels/managers.py
+++ b/polymodels/managers.py
@@ -6,7 +6,8 @@ from operator import methodcaller
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import ModelIterable
-from django.utils.six.moves import map
+
+from six.moves import map
 
 type_cast_iterator = partial(map, methodcaller('type_cast'))
 type_cast_prefetch_iterator = partial(map, methodcaller('type_cast', with_prefetched_objects=True))

--- a/polymodels/models.py
+++ b/polymodels/models.py
@@ -8,12 +8,16 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.db import models, transaction
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.signals import class_prepared
 from django.utils.functional import cached_property
 
 from .managers import PolymorphicManager
 from .utils import copy_fields, get_content_type, get_content_types
+
+try:
+    from django.core.exceptions import FieldDoesNotExist
+except ImportError:
+    from django.db.models.fields import FieldDoesNotExist
 
 
 class SubclassAccessor(namedtuple('SubclassAccessor', ['attrs', 'proxy', 'related_lookup'])):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author='Simon Charette',
     author_email='charette.s@gmail.com',
     install_requires=(
+        'six',
         'Django>=1.11',
     ),
     packages=find_packages(exclude=['tests', 'tests.*']),

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,10 +1,15 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from polymodels.fields import PolymorphicTypeField
 from polymodels.models import PolymorphicModel
+
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    def python_2_unicode_compatible(cls):
+        return cls
 
 
 class Zoo(models.Model):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -187,6 +187,13 @@ class PolymorphicTypeFieldTests(TestCase):
             # doesn't default to models.CASCADE anymore.
             if django.VERSION >= (1, 9):
                 deconstruction['on_delete'] = models.CASCADE
+
+            # As Django 3.1+ all field parameters are listed
+            if django.VERSION >= (3, 1):
+                deconstruction.update({
+                    'to': 'contenttypes.contenttype',
+                    'polymorphic_type': 'polymodels.Foo'
+                })
             return deconstruction
 
         self.assertDeconstructionEqual(Foo._meta.get_field('foo'), (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,9 +142,12 @@ class BasePolymorphicModelTest(TestCase):
 
     def test_delete_keep_parents(self):
         snake = HugeSnake.objects.create(name='snek', length=30)
+        animal_pk = snake.pk
         animal_content_type = ContentType.objects.get_for_model(Animal)
+
         snake.delete(keep_parents=True)
-        self.assertEqual(snake.animal_ptr.content_type, animal_content_type)
+        animal = Animal.objects.get(pk=animal_pk)
+        self.assertEqual(animal.content_type, animal_content_type)
 
 
 class SubclassAccessorsTests(SimpleTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ envlist =
     py27-1.11,
     py34-{1.11,2.0},
     py35-{1.11,2.0,2.1,2.2},
-    py36-{1.11,2.0,2.1,2.2,master},
-    py37-{2.0,2.1,2.2,master}
+    py36-{1.11,2.0,2.1,2.2,3.0,master},
+    py37-{2.0,2.1,2.2,3.0,master}
+    py38-{3.0,master}
 
 [testenv]
 basepython =
@@ -17,16 +18,19 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 usedevelop = true
 commands =
     {envpython} -R -Wonce {envbindir}/coverage run -m django test -v2 --settings=tests.settings {posargs}
     coverage report
 deps =
+    six
     coverage
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
     2.2: Django>=2.2a1,<3.0
+    3.0: Django>=3.0,<3.1
     master: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:flake8]


### PR DESCRIPTION
I have to modify a couple of tests. Django 3.0 seems clears pk on deleted models, so no further  back references are allowed. And Django 3.1 changed field deconstruction results